### PR TITLE
T as nda datatype carries tensor class

### DIFF
--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/AbstractTensor.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/AbstractTensor.java
@@ -37,7 +37,7 @@ import org.tensorflow.types.family.TType;
  *
  * <p>Usage of this class is meant to be kept internal.
  */
-public abstract class AbstractDenseTensor<T> implements Tensor<T> {
+public abstract class AbstractTensor<T> implements Tensor<T> {
 
   @Override
   @SuppressWarnings("unchecked")
@@ -74,7 +74,7 @@ public abstract class AbstractDenseTensor<T> implements Tensor<T> {
     return String.format("%s tensor with shape %s", dtype.toString(), shape());
   }
 
-  protected AbstractDenseTensor(TF_Tensor nativeHandle, DataType<?> dtype) {
+  protected AbstractTensor(TF_Tensor nativeHandle, DataType<?> dtype) {
     this.nativeHandle = nativeHandle;
     this.dtype = dtype;
     nativeHandle.retainReference();
@@ -100,6 +100,6 @@ public abstract class AbstractDenseTensor<T> implements Tensor<T> {
     return handle;
   }
 
-  private final TF_Tensor nativeHandle;
-  private final DataType<?> dtype;
+  protected final TF_Tensor nativeHandle;
+  protected final DataType<?> dtype;
 }

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/DataType.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/DataType.java
@@ -41,10 +41,12 @@ public final class DataType<T extends TType> {
    * @param name readable-name for this type
    * @param value must match the corresponding TF_* value in the TensorFlow C API.
    * @param byteSize size of an element of this type, in bytes, -1 if unknown
-   * @param tensorMapper method for instantiating tensor from a native reference
+   * @param tensorClass the subclass of {@link TType} that corresponds to this `DataType`
+   * @param instantiator method for instantiating tensor from a native reference
    */
-  public static <T extends TType> DataType<T> create(String name, int value, int byteSize, TensorInstantiator<T> instantiator) {
-    return new DataType<>(name, value, byteSize, instantiator);
+  public static <T extends TType> DataType<T> create(String name, int value, int byteSize,
+      Class<T> tensorClass, TensorInstantiator<T> instantiator) {
+    return new DataType<>(name, value, byteSize, tensorClass, instantiator);
   }
 
   /**
@@ -81,6 +83,20 @@ public final class DataType<T extends TType> {
   }
 
   /**
+   * Returns the subclass of {@link TType} that corresponds to this `DataType`.
+   */
+  public Class<?> getTensorClass() {
+    return tensorClass;
+  }
+
+  /**
+   * Indicates whether this <code>DataType</code>'s tensor class is a subtype of <code>ttype</code>.
+   */
+  public boolean hasType(Class<? extends TType<?, ?>> ttype) {
+    return ttype.isAssignableFrom(tensorClass);
+  }
+
+  /**
    * Instantiate a tensor of this datatype from the provided native handle
    *
    * @param handle tensor native handle
@@ -93,12 +109,15 @@ public final class DataType<T extends TType> {
   private final int nativeCode;
   private final int byteSize;
   private final String name;
+  private final Class<?> tensorClass;
   private final TensorInstantiator<T> tensorInstantiator;
 
-  private DataType(String name, int nativeCode, int byteSize, TensorInstantiator<T> tensorInstantiator) {
+  private DataType(String name, int nativeCode, int byteSize,
+      Class<?> tensorClass, TensorInstantiator<T> tensorInstantiator) {
     this.name = name;
     this.nativeCode = nativeCode;
     this.byteSize = byteSize;
+    this.tensorClass = tensorClass;
     this.tensorInstantiator = tensorInstantiator;
   }
 }

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/tensor/BooleanTensor.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/tensor/BooleanTensor.java
@@ -1,4 +1,4 @@
-package org.tensorflow.types.tensor;
+package org.tensorflow.tensor;
 
 import org.tensorflow.Tensor;
 import org.tensorflow.ndarray.BooleanNdArray;

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/tensor/ByteTensor.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/tensor/ByteTensor.java
@@ -1,4 +1,4 @@
-package org.tensorflow.types.tensor;
+package org.tensorflow.tensor;
 
 import org.tensorflow.Tensor;
 import org.tensorflow.ndarray.ByteNdArray;

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/tensor/DoubleTensor.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/tensor/DoubleTensor.java
@@ -1,4 +1,4 @@
-package org.tensorflow.types.tensor;
+package org.tensorflow.tensor;
 
 import org.tensorflow.Tensor;
 import org.tensorflow.ndarray.DoubleNdArray;

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/tensor/FloatTensor.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/tensor/FloatTensor.java
@@ -1,4 +1,4 @@
-package org.tensorflow.types.tensor;
+package org.tensorflow.tensor;
 
 import org.tensorflow.Tensor;
 import org.tensorflow.ndarray.FloatNdArray;

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/tensor/IntTensor.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/tensor/IntTensor.java
@@ -1,4 +1,4 @@
-package org.tensorflow.types.tensor;
+package org.tensorflow.tensor;
 
 import org.tensorflow.Tensor;
 import org.tensorflow.ndarray.IntNdArray;

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/tensor/LongTensor.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/tensor/LongTensor.java
@@ -1,4 +1,4 @@
-package org.tensorflow.types.tensor;
+package org.tensorflow.tensor;
 
 import org.tensorflow.Tensor;
 import org.tensorflow.ndarray.LongNdArray;

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/tensor/StringTensor.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/tensor/StringTensor.java
@@ -1,4 +1,4 @@
-package org.tensorflow.types.tensor;
+package org.tensorflow.tensor;
 
 import org.tensorflow.Tensor;
 import org.tensorflow.ndarray.NdArray;

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/types/TBfloat16.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/types/TBfloat16.java
@@ -50,7 +50,8 @@ import org.tensorflow.types.family.TFloating;
 public interface TBfloat16 extends FloatTensor, TFloating<TBfloat16, Float> {
 
   /** Type metadata */
-  DataType<TBfloat16> DTYPE = DataType.create("BFLOAT16", 14, 2, TBfloat16Impl::new);
+  DataType<TBfloat16> DTYPE = DataType.create("BFLOAT16", 14, 2,
+      TBfloat16.class, TBfloat16Impl::new);
 
   /**
    * Allocates a new tensor for storing a single float value.

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/types/TBool.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/types/TBool.java
@@ -43,7 +43,8 @@ import org.tensorflow.types.family.TType;
 public interface TBool extends BooleanTensor, TType<TBool, Boolean> {
 
   /** Type metadata */
-  DataType<TBool> DTYPE = DataType.create("BOOL", 10, 1, TBoolImpl::new);
+  DataType<TBool> DTYPE = DataType.create("BOOL", 10, 1,
+      TBool.class, TBoolImpl::new);
 
   /**
    * Allocates a new tensor for storing a single boolean value.

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/types/TFloat16.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/types/TFloat16.java
@@ -47,7 +47,8 @@ import org.tensorflow.types.family.TFloating;
 public interface TFloat16 extends FloatTensor, TFloating<TFloat16, Float> {
 
   /** Type metadata */
-  DataType<TFloat16> DTYPE = DataType.create("FLOAT16", 19, 2, TFloat16Impl::new);
+  DataType<TFloat16> DTYPE = DataType.create("FLOAT16", 19, 2,
+      TFloat16.class, TFloat16Impl::new);
 
   /**
    * Allocates a new tensor for storing a single float value.

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/types/TFloat32.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/types/TFloat32.java
@@ -37,7 +37,8 @@ import org.tensorflow.types.family.TFloating;
 public interface TFloat32 extends FloatTensor, TFloating<TFloat32, Float> {
 
   /** Type metadata */
-  DataType<TFloat32> DTYPE = DataType.create("FLOAT", 1, 4, TFloat32Impl::new);
+  DataType<TFloat32> DTYPE = DataType.create("FLOAT", 1, 4,
+      TFloat32.class, TFloat32Impl::new);
 
   /**
    * Allocates a new tensor for storing a single float value.

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/types/TFloat64.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/types/TFloat64.java
@@ -37,7 +37,8 @@ import org.tensorflow.types.family.TFloating;
 public interface TFloat64 extends DoubleTensor, TFloating<TFloat64, Double> {
 
   /** Type metadata */
-  DataType<TFloat64> DTYPE = DataType.create("DOUBLE", 2, 8, TFloat64Impl::new);
+  DataType<TFloat64> DTYPE = DataType.create("DOUBLE", 2, 8,
+      TFloat64.class, TFloat64Impl::new);
 
   /**
    * Allocates a new tensor for storing a single double value.

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/types/TInt32.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/types/TInt32.java
@@ -36,7 +36,8 @@ import org.tensorflow.types.family.TNumber;
 public interface TInt32 extends IntTensor, TNumber<TInt32, Integer> {
 
   /** Type metadata */
-  DataType<TInt32> DTYPE = DataType.create("INT32", 3, 4, TInt32Impl::new);
+  DataType<TInt32> DTYPE = DataType.create("INT32", 3, 4,
+      TInt32.class, TInt32Impl::new);
 
   /**
    * Allocates a new tensor for storing a single int value.

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/types/TInt64.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/types/TInt64.java
@@ -37,7 +37,8 @@ import org.tensorflow.types.family.TNumber;
 public interface TInt64 extends LongTensor, TNumber<TInt64, Long> {
 
   /** Type metadata */
-  DataType<TInt64> DTYPE = DataType.create("INT64", 9, 8, TInt64Impl::new);
+  DataType<TInt64> DTYPE = DataType.create("INT64", 9, 8,
+      TInt64.class, TInt64Impl::new);
 
   /**
    * Allocates a new tensor for storing a single long value.

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/types/TString.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/types/TString.java
@@ -49,7 +49,8 @@ public interface TString extends StringTensor, TType<TString, String> {
   /**
    * Type metadata
    */
-  DataType<TString> DTYPE = DataType.create("STRING", 7, -1, TStringImpl::new);
+  DataType<TString> DTYPE = DataType.create("STRING", 7, -1,
+      TString.class, TStringImpl::new);
 
   /**
    * Allocates a new tensor for storing a string scalar.

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/types/TUint8.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/types/TUint8.java
@@ -37,7 +37,8 @@ import org.tensorflow.types.family.TNumber;
 public interface TUint8 extends ByteTensor, TNumber<TUint8, Byte> {
 
   /** Type metadata */
-  DataType<TUint8> DTYPE = DataType.create("UINT8", 4, 1, TUint8Impl::new);
+  DataType<TUint8> DTYPE = DataType.create("UINT8", 4, 1,
+      TUint8.class, TUint8Impl::new);
 
   /**
    * Allocates a new tensor for storing a single byte value.


### PR DESCRIPTION
Baby step in shift from DataType to Tensor subclass as the main public API runtime representative of tensor type.