### PR TITLE
Fixes for our Javadoc.

### DIFF
--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/EagerSession.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/EagerSession.java
@@ -1,4 +1,4 @@
-/* Copyright 2019-2021 The TensorFlow Authors. All Rights Reserved.
+/* Copyright 2019-2024 The TensorFlow Authors. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -115,7 +115,7 @@ public final class EagerSession implements ExecutionEnvironment, AutoCloseable {
      *
      * @param config a config protocol buffer
      * @see <a
-     *     href="https://github.com/tensorflow/tensorflow/blob/master/tensorflow/core/protobuf/config.proto">config.proto</a></a>
+     *     href="https://github.com/tensorflow/tensorflow/blob/master/tensorflow/core/protobuf/config.proto">config.proto</a>
      */
     public Options config(ConfigProto config) {
       this.config = config;

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/SavedModelBundle.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/SavedModelBundle.java
@@ -1,4 +1,4 @@
-/* Copyright 2019-2021 The TensorFlow Authors. All Rights Reserved.
+/* Copyright 2019-2024 The TensorFlow Authors. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -250,7 +250,7 @@ public class SavedModelBundle implements AutoCloseable {
     /**
      * Add multiple signatures to the model. Wraps {@link #withSignature(Signature)}
      *
-     * <p><b>Either {@link #withSession(Session)} or {@link * #withFunction(SessionFunction)} must
+     * <p><b>Either {@link #withSession(Session)} or {@link #withFunction(SessionFunction)} must
      * be called before this method</b>, and the session set there will be used for these
      * signatures.
      *

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/Tensor.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/Tensor.java
@@ -1,4 +1,4 @@
-/* Copyright 2016 The TensorFlow Authors. All Rights Reserved.
+/* Copyright 2016-2024 The TensorFlow Authors. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -207,10 +207,10 @@ public interface Tensor extends Shaped, AutoCloseable {
   /**
    * Check if this tensor is sparse or not.
    *
-   * <p>When this methods retuns {@code true}, the tensor could be cast to a {@link SparseTensor
-   * SparseTensor<T>} to access its <i>indices</i>, <i>values</i> and <i>denseShape</i> tensors.
+   * <p>When this method returns {@code true}, the tensor could be cast to a {@link SparseTensor} to access its
+   * <i>indices</i>, <i>values</i> and <i>denseShape</i> tensors.
    *
-   * @return true if this tensor is a sparse
+   * @return true if this tensor is a sparse tensor.
    */
   default boolean isSparse() {
     return false;

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/TensorMapper.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/TensorMapper.java
@@ -49,8 +49,7 @@ public abstract class TensorMapper<T extends TType> {
    *     space.
    * @param tensorScope scope to extend to keep a reference on the sub-tensors composing this sparse
    *     tensor
-   * @return an instance of {@code T}, that could also be casted to a {@link SparseTensor
-   *     SparseTensor<T>}
+   * @return an instance of {@code T}.
    */
   protected abstract SparseTensor<T> mapSparse(
       TInt64 indices, T values, TInt64 denseShape, PointerScope tensorScope);

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/op/core/Function.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/op/core/Function.java
@@ -1,4 +1,4 @@
-/* Copyright 2020-2021 The TensorFlow Authors. All Rights Reserved.
+/* Copyright 2020-2024 The TensorFlow Authors. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -26,6 +26,11 @@ import org.tensorflow.op.annotation.Operator;
 /** Ops for calling {@link ConcreteFunction}. */
 @Operator(name = "call")
 public abstract class Function {
+
+  /**
+   * Constructor.
+   */
+  public Function() {}
 
   /**
    * Calls the function in an execution environment, adding its graph as a function if it isn't

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/op/core/Shapes.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/op/core/Shapes.java
@@ -1,4 +1,4 @@
-/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+/* Copyright 2020-2024 The TensorFlow Authors. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -389,7 +389,7 @@ public abstract class Shapes {
    *
    * @param scope current scope
    * @param shape the TensorFlow shape
-   * @param n the number of leading dimensions to get, must be <= than the shape's numDimensions()
+   * @param n the number of leading dimensions to get, must be less than or equal to the shape's numDimensions()
    * @return a 1-dimensional operand with the dimensions matching the first n dimensions of the
    *     shape
    */
@@ -404,7 +404,7 @@ public abstract class Shapes {
    *
    * @param scope current scope
    * @param shape the TensorFlow shape
-   * @param n the number of leading dimensions to get, must be <= than the shape's numDimensions()
+   * @param n the number of leading dimensions to get, must be less than or equal to the shape's numDimensions()
    * @param type the shape datatype.
    * @param <U> the shape datatype.
    * @return a 1-dimensional operand with the dimensions matching * the first n dimensions of the
@@ -456,7 +456,7 @@ public abstract class Shapes {
    *
    * @param scope current scope
    * @param shape the TensorFlow shape
-   * @param n the number of leading dimensions to get, must be <= than the shape's numDimensions()
+   * @param n the number of leading dimensions to get, must be less than or equal to the shape's numDimensions()
    * @return a 1-dimensional operand containing the dimensions matching the last n dimensions of the
    *     shape
    */
@@ -472,7 +472,7 @@ public abstract class Shapes {
    *
    * @param scope current scope
    * @param shape the TensorFlow shape
-   * @param n the number of leading dimensions to get, must be <= than the shape's numDimensions()
+   * @param n the number of leading dimensions to get, must be less than or equal to the shape's numDimensions()
    * @param type the shape datatype.
    * @param <U> the shape datatype.
    * @return a 1-dimensional operand containing the dimensions matching the last n dimensions of the

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/op/core/StridedSliceHelper.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/op/core/StridedSliceHelper.java
@@ -1,4 +1,4 @@
-/* Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+/* Copyright 2020-2024 The TensorFlow Authors. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -210,9 +210,9 @@ public abstract class StridedSliceHelper {
    * @param scope current scope
    * @param ref the tensor to assign to.
    * @param value the value to assign.
-   * @param indices The indices to slice. See {@link Indices}.
+   * @param indices The indices to slice. See {@link org.tensorflow.ndarray.index.Indices}.
    * @return a new instance of StridedSliceAssign
-   * @see org.tensorflow.op.Ops#stridedSlice(Operand, Index...)
+   * @see org.tensorflow.op.Ops#stridedSlice(org.tensorflow.Operand, org.tensorflow.ndarray.index.Index...)
    */
   @Endpoint(name = "stridedSliceAssign")
   public static <T extends TType> StridedSliceAssign<T> stridedSliceAssign(

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/types/TBfloat16.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/types/TBfloat16.java
@@ -120,10 +120,10 @@ public interface TBfloat16 extends FloatNdArray, TFloating {
   }
 
   /**
-   * Create a sparse tensors from {@code indices}, {@code values} and {@code denseShape} dense
+   * Create a sparse tensor from {@code indices}, {@code values} and {@code denseShape} dense
    * tensors, with a default value of zero.
    *
-   * <p>The returned instance also implements the {@link SparseTensor SparseTensor<TBfloat16>}
+   * <p>The returned instance also implements the {@link SparseTensor}
    * interface, allowing a user to access directly the dense tensors when needed.
    *
    * @param indices A 2-D tensor of shape {@code [N, ndims]}, that specifies the indices of the

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/types/TBool.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/types/TBool.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+ *  Copyright 2019-2024 The TensorFlow Authors. All Rights Reserved.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -111,10 +111,10 @@ public interface TBool extends BooleanNdArray, TType {
   }
 
   /**
-   * Create a sparse tensors from {@code indices}, {@code values} and {@code denseShape} dense
+   * Create a sparse tensor from {@code indices}, {@code values} and {@code denseShape} dense
    * tensors, with a default value of {@code false}.
    *
-   * <p>The returned instance also implements the {@link SparseTensor SparseTensor<TBool>}
+   * <p>The returned instance also implements the {@link SparseTensor}
    * interface, allowing a user to access directly the dense tensors when needed.
    *
    * @param indices A 2-D tensor of shape {@code [N, ndims]}, that specifies the indices of the

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/types/TFloat16.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/types/TFloat16.java
@@ -117,10 +117,10 @@ public interface TFloat16 extends FloatNdArray, TFloating {
   }
 
   /**
-   * Create a sparse tensors from {@code indices}, {@code values} and {@code denseShape} dense
+   * Create a sparse tensor from {@code indices}, {@code values} and {@code denseShape} dense
    * tensors, with a default value of zero.
    *
-   * <p>The returned instance also implements the {@link SparseTensor SparseTensor<TFloat16>}
+   * <p>The returned instance also implements the {@link SparseTensor}
    * interface, allowing a user to access directly the dense tensors when needed.
    *
    * @param indices A 2-D tensor of shape {@code [N, ndims]}, that specifies the indices of the

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/types/TFloat32.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/types/TFloat32.java
@@ -105,10 +105,10 @@ public interface TFloat32 extends FloatNdArray, TFloating {
   }
 
   /**
-   * Create a sparse tensors from {@code indices}, {@code values} and {@code denseShape} dense
+   * Create a sparse tensor from {@code indices}, {@code values} and {@code denseShape} dense
    * tensors, with a default value of zero.
    *
-   * <p>The returned instance also implements the {@link SparseTensor SparseTensor<TFloat32>}
+   * <p>The returned instance also implements the {@link SparseTensor}
    * interface, allowing a user to access directly the dense tensors when needed.
    *
    * @param indices A 2-D tensor of shape {@code [N, ndims]}, that specifies the indices of the

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/types/TFloat64.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/types/TFloat64.java
@@ -105,10 +105,10 @@ public interface TFloat64 extends DoubleNdArray, TFloating {
   }
 
   /**
-   * Create a sparse tensors from {@code indices}, {@code values} and {@code denseShape} dense
+   * Create a sparse tensor from {@code indices}, {@code values} and {@code denseShape} dense
    * tensors, with a default value of zero.
    *
-   * <p>The returned instance also implements the {@link SparseTensor SparseTensor<TFloat64>}
+   * <p>The returned instance also implements the {@link SparseTensor}
    * interface, allowing a user to access directly the dense tensors when needed.
    *
    * @param indices A 2-D tensor of shape {@code [N, ndims]}, that specifies the indices of the

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/types/TInt32.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/types/TInt32.java
@@ -103,10 +103,10 @@ public interface TInt32 extends IntNdArray, TIntegral {
   }
 
   /**
-   * Create a sparse tensors from {@code indices}, {@code values} and {@code denseShape} dense
+   * Create a sparse tensor from {@code indices}, {@code values} and {@code denseShape} dense
    * tensors, with a default value of zero.
    *
-   * <p>The returned instance also implements the {@link SparseTensor SparseTensor<TInt32>}
+   * <p>The returned instance also implements the {@link SparseTensor}
    * interface, allowing a user to access directly the dense tensors when needed.
    *
    * @param indices A 2-D tensor of shape {@code [N, ndims]}, that specifies the indices of the

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/types/TInt64.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/types/TInt64.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+ *  Copyright 2019-2024 The TensorFlow Authors. All Rights Reserved.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -104,10 +104,10 @@ public interface TInt64 extends LongNdArray, TIntegral {
   }
 
   /**
-   * Create a sparse tensors from {@code indices}, {@code values} and {@code denseShape} dense
+   * Create a sparse tensor from {@code indices}, {@code values} and {@code denseShape} dense
    * tensors, with a default value of zero.
    *
-   * <p>The returned instance also implements the {@link SparseTensor SparseTensor<TInt64>}
+   * <p>The returned instance also implements the {@link SparseTensor}
    * interface, allowing a user to access directly the dense tensors when needed.
    *
    * @param indices A 2-D tensor of shape {@code [N, ndims]}, that specifies the indices of the

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/types/TString.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/types/TString.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+ *  Copyright 2019-2024 The TensorFlow Authors. All Rights Reserved.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -131,7 +131,7 @@ public interface TString extends NdArray<String>, TType {
    * <p>The data will be copied from the provided buffer to the tensor after it is allocated. The
    * strings are encoded into bytes using the charset passed in parameter.
    *
-   * <p>If charset is different than default UTF-8, then it must also be provided explicitly when
+   * <p>If charset is different from the default UTF-8, then it must also be provided explicitly when
    * reading data from the tensor, using {@link #using(Charset)}:
    *
    * <pre>{@code
@@ -193,10 +193,10 @@ public interface TString extends NdArray<String>, TType {
   }
 
   /**
-   * Create a sparse tensors from {@code indices}, {@code values} and {@code denseShape} dense
+   * Create a sparse tensor from {@code indices}, {@code values} and {@code denseShape} dense
    * tensors, with an empty string as the default value.
    *
-   * <p>The returned instance also implements the {@link SparseTensor SparseTensor<TString>}
+   * <p>The returned instance also implements the {@link SparseTensor}
    * interface, allowing a user to access directly the dense tensors when needed.
    *
    * @param indices A 2-D tensor of shape {@code [N, ndims]}, that specifies the indices of the

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/types/TUint16.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/types/TUint16.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2022 The TensorFlow Authors. All Rights Reserved.
+ *  Copyright 2022-2024 The TensorFlow Authors. All Rights Reserved.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -105,10 +105,10 @@ public interface TUint16 extends ShortNdArray, TIntegral {
   }
 
   /**
-   * Create a sparse tensors from {@code indices}, {@code values} and {@code denseShape} dense
+   * Create a sparse tensor from {@code indices}, {@code values} and {@code denseShape} dense
    * tensors, with a default value of zero.
    *
-   * <p>The returned instance also implements the {@link SparseTensor SparseTensor<TUint16>}
+   * <p>The returned instance also implements the {@link SparseTensor}
    * interface, allowing a user to access directly the dense tensors when needed.
    *
    * @param indices A 2-D tensor of shape {@code [N, ndims]}, that specifies the indices of the

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/types/TUint8.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/types/TUint8.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+ *  Copyright 2019-2024 The TensorFlow Authors. All Rights Reserved.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -104,10 +104,10 @@ public interface TUint8 extends ByteNdArray, TIntegral {
   }
 
   /**
-   * Create a sparse tensors from {@code indices}, {@code values} and {@code denseShape} dense
+   * Create a sparse tensor from {@code indices}, {@code values} and {@code denseShape} dense
    * tensors, with a default value of zero.
    *
-   * <p>The returned instance also implements the {@link SparseTensor SparseTensor<TUint8>}
+   * <p>The returned instance also implements the {@link SparseTensor}
    * interface, allowing a user to access directly the dense tensors when needed.
    *
    * @param indices A 2-D tensor of shape {@code [N, ndims]}, that specifies the indices of the

--- a/tensorflow-core/tensorflow-core-generator/pom.xml
+++ b/tensorflow-core/tensorflow-core-generator/pom.xml
@@ -44,7 +44,7 @@
     <dependency>
       <groupId>com.squareup</groupId>
       <artifactId>javapoet</artifactId>
-      <version>1.12.1</version>
+      <version>1.13.0</version>
     </dependency>
     <dependency>
       <groupId>com.google.protobuf</groupId>
@@ -61,6 +61,16 @@
       <groupId>org.commonmark</groupId>
       <artifactId>commonmark</artifactId>
       <version>0.17.1</version>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
This tidies up all remaining javadoc errors in the code we wrote in tensorflow-core-api. The generator is still emitting malformed html tags (missing `</div>` and escaping `</b>`) and unexpectedly adding extra generic type parameters (I think this occurs when the output type is generic but fixed).