### PR TITLE
Fixing closing tags

### DIFF
--- a/tensorflow-core/tensorflow-core-api/src/api/api_def_SegmentSumV2.pbtxt
+++ b/tensorflow-core/tensorflow-core-api/src/api/api_def_SegmentSumV2.pbtxt
@@ -4,4 +4,18 @@ op {
   endpoint {
     name: "math.SegmentSum"
   }
+  description: <<END
+Read
+[the section on segmentation](https://tensorflow.org/api_docs/python/tf/math#Segmentation)
+for an explanation of segments.
+
+Computes a tensor such that
+\\(output_i = \sum_j data_j\\) where sum is over `j` such
+that `segment_ids[j] == i`.
+
+If the sum is empty for a given segment ID `i`, `output[i] = 0`.
+
+Note that this op is currently only supported with jit_compile=True.
+
+END
 }

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/SavedModelBundle.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/SavedModelBundle.java
@@ -250,9 +250,8 @@ public class SavedModelBundle implements AutoCloseable {
     /**
      * Add multiple signatures to the model. Wraps {@link #withSignature(Signature)}
      *
-     * <p><b>Either {@link #withSession(Session)} or {@link #withFunction(SessionFunction)} must
-     * be called before this method</b>, and the session set there will be used for these
-     * signatures.
+     * <p><b>Either {@link #withSession(Session)} or {@link #withFunction(SessionFunction)} must be
+     * called before this method</b>, and the session set there will be used for these signatures.
      *
      * @throws IllegalStateException if no session has been set
      * @return this

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/Session.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/Session.java
@@ -221,8 +221,8 @@ public final class Session implements AutoCloseable {
      * Avoid evaluating {@code operation} and substitute {@code t} for the value it produces.
      *
      * @param operation Is either the string name of the operation, in which case this method is a
-     *     shorthand for {@code feed(operation, 0)}, or it is a string of the form
-     *     {@code operation_name:output_index}, in which case this method acts like {@code
+     *     shorthand for {@code feed(operation, 0)}, or it is a string of the form {@code
+     *     operation_name:output_index}, in which case this method acts like {@code
      *     feed(operation_name, output_index)}. These colon-separated names are commonly used in the
      *     {@code SignatureDef} protocol buffer messages that are included in {@link
      *     SavedModelBundle#metaGraphDef()}.
@@ -283,8 +283,8 @@ public final class Session implements AutoCloseable {
      * <p>If the output is a resource variable, will fetch the value.
      *
      * @param operation Is either the string name of the operation, in which case this method is a
-     *     shorthand for {@code fetch(operation, 0)}, or it is a string of the form
-     *     {@code operation_name:output_index}, in which case this method acts like {@code
+     *     shorthand for {@code fetch(operation, 0)}, or it is a string of the form {@code
+     *     operation_name:output_index}, in which case this method acts like {@code
      *     fetch(operation_name, output_index)}. These colon-separated names are commonly used in
      *     the {@code SignatureDef} protocol buffer messages that are included in {@link
      *     SavedModelBundle#metaGraphDef()}.

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/Tensor.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/Tensor.java
@@ -207,8 +207,8 @@ public interface Tensor extends Shaped, AutoCloseable {
   /**
    * Check if this tensor is sparse or not.
    *
-   * <p>When this method returns {@code true}, the tensor could be cast to a {@link SparseTensor} to access its
-   * <i>indices</i>, <i>values</i> and <i>denseShape</i> tensors.
+   * <p>When this method returns {@code true}, the tensor could be cast to a {@link SparseTensor} to
+   * access its <i>indices</i>, <i>values</i> and <i>denseShape</i> tensors.
    *
    * @return true if this tensor is a sparse tensor.
    */

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/op/core/Function.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/op/core/Function.java
@@ -27,9 +27,7 @@ import org.tensorflow.op.annotation.Operator;
 @Operator(name = "call")
 public abstract class Function {
 
-  /**
-   * Constructor.
-   */
+  /** Constructor. */
   public Function() {}
 
   /**

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/op/core/Shapes.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/op/core/Shapes.java
@@ -389,7 +389,8 @@ public abstract class Shapes {
    *
    * @param scope current scope
    * @param shape the TensorFlow shape
-   * @param n the number of leading dimensions to get, must be less than or equal to the shape's numDimensions()
+   * @param n the number of leading dimensions to get, must be less than or equal to the shape's
+   *     numDimensions()
    * @return a 1-dimensional operand with the dimensions matching the first n dimensions of the
    *     shape
    */
@@ -404,7 +405,8 @@ public abstract class Shapes {
    *
    * @param scope current scope
    * @param shape the TensorFlow shape
-   * @param n the number of leading dimensions to get, must be less than or equal to the shape's numDimensions()
+   * @param n the number of leading dimensions to get, must be less than or equal to the shape's
+   *     numDimensions()
    * @param type the shape datatype.
    * @param <U> the shape datatype.
    * @return a 1-dimensional operand with the dimensions matching * the first n dimensions of the
@@ -456,7 +458,8 @@ public abstract class Shapes {
    *
    * @param scope current scope
    * @param shape the TensorFlow shape
-   * @param n the number of leading dimensions to get, must be less than or equal to the shape's numDimensions()
+   * @param n the number of leading dimensions to get, must be less than or equal to the shape's
+   *     numDimensions()
    * @return a 1-dimensional operand containing the dimensions matching the last n dimensions of the
    *     shape
    */
@@ -472,7 +475,8 @@ public abstract class Shapes {
    *
    * @param scope current scope
    * @param shape the TensorFlow shape
-   * @param n the number of leading dimensions to get, must be less than or equal to the shape's numDimensions()
+   * @param n the number of leading dimensions to get, must be less than or equal to the shape's
+   *     numDimensions()
    * @param type the shape datatype.
    * @param <U> the shape datatype.
    * @return a 1-dimensional operand containing the dimensions matching the last n dimensions of the

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/op/core/StridedSliceHelper.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/op/core/StridedSliceHelper.java
@@ -137,16 +137,17 @@ public abstract class StridedSliceHelper {
    * equal to `n`, but this need not be the case. Each range specification entry can be one of the
    * following:
    *
-   * <p>- An ellipsis (...) using {@link org.tensorflow.ndarray.index.Indices#ellipsis()}. Ellipses are used to imply zero or
-   * more dimensions of full-dimension selection. For example, {@code stridedSlice(foo,
-   * Indices.ellipsis()} is the identity slice.
+   * <p>- An ellipsis (...) using {@link org.tensorflow.ndarray.index.Indices#ellipsis()}. Ellipses
+   * are used to imply zero or more dimensions of full-dimension selection. For example, {@code
+   * stridedSlice(foo, Indices.ellipsis()} is the identity slice.
    *
-   * <p>- A new axis using {@link org.tensorflow.ndarray.index.Indices#newAxis()}. This is used to insert a new shape=1
-   * dimension. For example, `{@code stridedSlice(foo, Indices.newAxis())} where {@code foo} is
-   * shape {@code (3, 4)} produces a {@code (1, 3, 4)} tensor.
+   * <p>- A new axis using {@link org.tensorflow.ndarray.index.Indices#newAxis()}. This is used to
+   * insert a new shape=1 dimension. For example, `{@code stridedSlice(foo, Indices.newAxis())}
+   * where {@code foo} is shape {@code (3, 4)} produces a {@code (1, 3, 4)} tensor.
    *
-   * <p>- A range {@code begin:end:stride} using {@link org.tensorflow.ndarray.index.Indices#slice(Long, Long, long)}
-   * Index.slice()} or {@link org.tensorflow.ndarray.index.Indices#all()}. This is used to specify how much to choose from a
+   * <p>- A range {@code begin:end:stride} using {@link
+   * org.tensorflow.ndarray.index.Indices#slice(Long, Long, long)} Index.slice()} or {@link
+   * org.tensorflow.ndarray.index.Indices#all()}. This is used to specify how much to choose from a
    * given dimension. {@code stride} can be any integer but 0. {@code begin} is an integer which
    * represents the index of the first value to select while {@code end} represents the index of the
    * last value to select (exclusive). Begin and end can be null, in which case the index begins or
@@ -163,10 +164,11 @@ public abstract class StridedSliceHelper {
    * elements). For example {@code foo = [1,2,3,4]; stridedSlice(foo, Indices.slice(-2, null, -1)}
    * is {@code [4,3]}.
    *
-   * <p>- A single index using {@link org.tensorflow.ndarray.index.Indices#at(long)}. This is used to keep only elements that
-   * have a given index. For example ({@code stridedSlice(foo, Indices.at(2))} on a shape {@code
-   * (5,6)} tensor produces a shape {@code (6,)} tensor. The dimension can be kept with size one
-   * using {@link org.tensorflow.ndarray.index.Indices#at(long, boolean)}.
+   * <p>- A single index using {@link org.tensorflow.ndarray.index.Indices#at(long)}. This is used
+   * to keep only elements that have a given index. For example ({@code stridedSlice(foo,
+   * Indices.at(2))} on a shape {@code (5,6)} tensor produces a shape {@code (6,)} tensor. The
+   * dimension can be kept with size one using {@link org.tensorflow.ndarray.index.Indices#at(long,
+   * boolean)}.
    *
    * <p>These semantics generally follow NumPy's indexing semantics, which can be found here: <a
    * href="https://numpy.org/doc/stable/reference/arrays.indexing.html">https://numpy.org/doc/stable/reference/arrays.indexing.html</a>
@@ -212,7 +214,8 @@ public abstract class StridedSliceHelper {
    * @param value the value to assign.
    * @param indices The indices to slice. See {@link org.tensorflow.ndarray.index.Indices}.
    * @return a new instance of StridedSliceAssign
-   * @see org.tensorflow.op.Ops#stridedSlice(org.tensorflow.Operand, org.tensorflow.ndarray.index.Index...)
+   * @see org.tensorflow.op.Ops#stridedSlice(org.tensorflow.Operand,
+   *     org.tensorflow.ndarray.index.Index...)
    */
   @Endpoint(name = "stridedSliceAssign")
   public static <T extends TType> StridedSliceAssign<T> stridedSliceAssign(

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/types/TBfloat16.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/types/TBfloat16.java
@@ -123,8 +123,8 @@ public interface TBfloat16 extends FloatNdArray, TFloating {
    * Create a sparse tensor from {@code indices}, {@code values} and {@code denseShape} dense
    * tensors, with a default value of zero.
    *
-   * <p>The returned instance also implements the {@link SparseTensor}
-   * interface, allowing a user to access directly the dense tensors when needed.
+   * <p>The returned instance also implements the {@link SparseTensor} interface, allowing a user to
+   * access directly the dense tensors when needed.
    *
    * @param indices A 2-D tensor of shape {@code [N, ndims]}, that specifies the indices of the
    *     elements in the sparse tensor that contain non-default values (elements are zero-indexed).

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/types/TBool.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/types/TBool.java
@@ -114,8 +114,8 @@ public interface TBool extends BooleanNdArray, TType {
    * Create a sparse tensor from {@code indices}, {@code values} and {@code denseShape} dense
    * tensors, with a default value of {@code false}.
    *
-   * <p>The returned instance also implements the {@link SparseTensor}
-   * interface, allowing a user to access directly the dense tensors when needed.
+   * <p>The returned instance also implements the {@link SparseTensor} interface, allowing a user to
+   * access directly the dense tensors when needed.
    *
    * @param indices A 2-D tensor of shape {@code [N, ndims]}, that specifies the indices of the
    *     elements in the sparse tensor that contain non-default values (elements are zero-indexed).

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/types/TFloat16.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/types/TFloat16.java
@@ -120,8 +120,8 @@ public interface TFloat16 extends FloatNdArray, TFloating {
    * Create a sparse tensor from {@code indices}, {@code values} and {@code denseShape} dense
    * tensors, with a default value of zero.
    *
-   * <p>The returned instance also implements the {@link SparseTensor}
-   * interface, allowing a user to access directly the dense tensors when needed.
+   * <p>The returned instance also implements the {@link SparseTensor} interface, allowing a user to
+   * access directly the dense tensors when needed.
    *
    * @param indices A 2-D tensor of shape {@code [N, ndims]}, that specifies the indices of the
    *     elements in the sparse tensor that contain non-default values (elements are zero-indexed).

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/types/TFloat32.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/types/TFloat32.java
@@ -108,8 +108,8 @@ public interface TFloat32 extends FloatNdArray, TFloating {
    * Create a sparse tensor from {@code indices}, {@code values} and {@code denseShape} dense
    * tensors, with a default value of zero.
    *
-   * <p>The returned instance also implements the {@link SparseTensor}
-   * interface, allowing a user to access directly the dense tensors when needed.
+   * <p>The returned instance also implements the {@link SparseTensor} interface, allowing a user to
+   * access directly the dense tensors when needed.
    *
    * @param indices A 2-D tensor of shape {@code [N, ndims]}, that specifies the indices of the
    *     elements in the sparse tensor that contain non-default values (elements are zero-indexed).

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/types/TFloat64.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/types/TFloat64.java
@@ -108,8 +108,8 @@ public interface TFloat64 extends DoubleNdArray, TFloating {
    * Create a sparse tensor from {@code indices}, {@code values} and {@code denseShape} dense
    * tensors, with a default value of zero.
    *
-   * <p>The returned instance also implements the {@link SparseTensor}
-   * interface, allowing a user to access directly the dense tensors when needed.
+   * <p>The returned instance also implements the {@link SparseTensor} interface, allowing a user to
+   * access directly the dense tensors when needed.
    *
    * @param indices A 2-D tensor of shape {@code [N, ndims]}, that specifies the indices of the
    *     elements in the sparse tensor that contain non-default values (elements are zero-indexed).

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/types/TInt32.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/types/TInt32.java
@@ -106,8 +106,8 @@ public interface TInt32 extends IntNdArray, TIntegral {
    * Create a sparse tensor from {@code indices}, {@code values} and {@code denseShape} dense
    * tensors, with a default value of zero.
    *
-   * <p>The returned instance also implements the {@link SparseTensor}
-   * interface, allowing a user to access directly the dense tensors when needed.
+   * <p>The returned instance also implements the {@link SparseTensor} interface, allowing a user to
+   * access directly the dense tensors when needed.
    *
    * @param indices A 2-D tensor of shape {@code [N, ndims]}, that specifies the indices of the
    *     elements in the sparse tensor that contain non-default values (elements are zero-indexed).

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/types/TInt64.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/types/TInt64.java
@@ -107,8 +107,8 @@ public interface TInt64 extends LongNdArray, TIntegral {
    * Create a sparse tensor from {@code indices}, {@code values} and {@code denseShape} dense
    * tensors, with a default value of zero.
    *
-   * <p>The returned instance also implements the {@link SparseTensor}
-   * interface, allowing a user to access directly the dense tensors when needed.
+   * <p>The returned instance also implements the {@link SparseTensor} interface, allowing a user to
+   * access directly the dense tensors when needed.
    *
    * @param indices A 2-D tensor of shape {@code [N, ndims]}, that specifies the indices of the
    *     elements in the sparse tensor that contain non-default values (elements are zero-indexed).

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/types/TString.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/types/TString.java
@@ -131,8 +131,8 @@ public interface TString extends NdArray<String>, TType {
    * <p>The data will be copied from the provided buffer to the tensor after it is allocated. The
    * strings are encoded into bytes using the charset passed in parameter.
    *
-   * <p>If charset is different from the default UTF-8, then it must also be provided explicitly when
-   * reading data from the tensor, using {@link #using(Charset)}:
+   * <p>If charset is different from the default UTF-8, then it must also be provided explicitly
+   * when reading data from the tensor, using {@link #using(Charset)}:
    *
    * <pre>{@code
    * // Given `originalStrings` an initialized buffer of strings
@@ -196,8 +196,8 @@ public interface TString extends NdArray<String>, TType {
    * Create a sparse tensor from {@code indices}, {@code values} and {@code denseShape} dense
    * tensors, with an empty string as the default value.
    *
-   * <p>The returned instance also implements the {@link SparseTensor}
-   * interface, allowing a user to access directly the dense tensors when needed.
+   * <p>The returned instance also implements the {@link SparseTensor} interface, allowing a user to
+   * access directly the dense tensors when needed.
    *
    * @param indices A 2-D tensor of shape {@code [N, ndims]}, that specifies the indices of the
    *     elements in the sparse tensor that contain non-default values (elements are zero-indexed).

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/types/TUint16.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/types/TUint16.java
@@ -108,8 +108,8 @@ public interface TUint16 extends ShortNdArray, TIntegral {
    * Create a sparse tensor from {@code indices}, {@code values} and {@code denseShape} dense
    * tensors, with a default value of zero.
    *
-   * <p>The returned instance also implements the {@link SparseTensor}
-   * interface, allowing a user to access directly the dense tensors when needed.
+   * <p>The returned instance also implements the {@link SparseTensor} interface, allowing a user to
+   * access directly the dense tensors when needed.
    *
    * @param indices A 2-D tensor of shape {@code [N, ndims]}, that specifies the indices of the
    *     elements in the sparse tensor that contain non-default values (elements are zero-indexed).

--- a/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/types/TUint8.java
+++ b/tensorflow-core/tensorflow-core-api/src/main/java/org/tensorflow/types/TUint8.java
@@ -107,8 +107,8 @@ public interface TUint8 extends ByteNdArray, TIntegral {
    * Create a sparse tensor from {@code indices}, {@code values} and {@code denseShape} dense
    * tensors, with a default value of zero.
    *
-   * <p>The returned instance also implements the {@link SparseTensor}
-   * interface, allowing a user to access directly the dense tensors when needed.
+   * <p>The returned instance also implements the {@link SparseTensor} interface, allowing a user to
+   * access directly the dense tensors when needed.
    *
    * @param indices A 2-D tensor of shape {@code [N, ndims]}, that specifies the indices of the
    *     elements in the sparse tensor that contain non-default values (elements are zero-indexed).

--- a/tensorflow-core/tensorflow-core-generator/src/main/java/org/tensorflow/generator/op/ClassGenerator.java
+++ b/tensorflow-core/tensorflow-core-generator/src/main/java/org/tensorflow/generator/op/ClassGenerator.java
@@ -297,8 +297,10 @@ final class ClassGenerator {
         if (seenGenerics.add(typeVar.name)) {
           typeParams.add(typeVar);
           builder.addTypeVariable(typeVar);
-          builder.addJavadoc(
-              "\n@param <$L> data type for {@code $L} output\n", typeVar.name, output.getName());
+          // FIXME: check if we need to add this or if it's redundant now with other type
+          // generations.
+          // builder.addJavadoc("\n@param <$L> data type for {@code $L} output\n", typeVar.name,
+          // output.getName());
         }
       }
     }

--- a/tensorflow-core/tensorflow-core-generator/src/main/java/org/tensorflow/generator/op/javadoc/CoreJavaDocNodeRenderer.java
+++ b/tensorflow-core/tensorflow-core-generator/src/main/java/org/tensorflow/generator/op/javadoc/CoreJavaDocNodeRenderer.java
@@ -427,7 +427,7 @@ public class CoreJavaDocNodeRenderer extends AbstractVisitor implements NodeRend
   public void visit(HtmlInline htmlInline) {
     String text = htmlInline.getLiteral();
     // handle non- JavaDoc html, e.g. <bytes>
-    String tag = text.replace("\\", "");
+    String tag = text.replace("/", "");
     if (!allowedHtml5Tags.contains(tag.toLowerCase())) {
       text = text.replace("<", "&lt;").replace(">", "&gt;");
       writer.raw(text);

--- a/tensorflow-core/tensorflow-core-generator/src/main/java/org/tensorflow/generator/op/javadoc/JavaDocRenderer.java
+++ b/tensorflow-core/tensorflow-core-generator/src/main/java/org/tensorflow/generator/op/javadoc/JavaDocRenderer.java
@@ -65,13 +65,7 @@ public class JavaDocRenderer implements Renderer {
     this.nodeRendererFactories = new ArrayList<>(builder.nodeRendererFactories.size() + 1);
     this.nodeRendererFactories.addAll(builder.nodeRendererFactories);
     // Add as last. This means clients can override the rendering of core nodes if they want.
-    this.nodeRendererFactories.add(
-        new JavaDocNodeRendererFactory() {
-          @Override
-          public NodeRenderer create(JavaDocNodeRendererContext context) {
-            return new CoreJavaDocNodeRenderer(context);
-          }
-        });
+    this.nodeRendererFactories.add(CoreJavaDocNodeRenderer::new);
   }
 
   /**

--- a/tensorflow-core/tensorflow-core-generator/src/main/java/org/tensorflow/generator/op/processor/OperatorProcessor.java
+++ b/tensorflow-core/tensorflow-core-generator/src/main/java/org/tensorflow/generator/op/processor/OperatorProcessor.java
@@ -459,8 +459,7 @@ public final class OperatorProcessor extends AbstractProcessor {
         TypeSpec.classBuilder(spec.className)
             .addModifiers(Modifier.PUBLIC, Modifier.FINAL)
             .addJavadoc(
-                "An API for building {@code $L} operations as {@link $T Op}s\n\n"
-                    + "@see $T\n",
+                "An API for building {@code $L} operations as {@link $T Op}s\n\n" + "@see $T\n",
                 spec.groupName,
                 Names.Op,
                 Names.Ops)


### PR DESCRIPTION
Override SegumentSumV2 description as it has a stray unpaired `</div>` and fix the check in `CoreJavaDocNodeRenderer` so it properly detects closing tags.